### PR TITLE
Fix port issue on online servers

### DIFF
--- a/app.js
+++ b/app.js
@@ -122,6 +122,6 @@ app.post("/delete", function(req, res){
 
 });
 
-app.listen(3000, function() {
-  console.log("Server started port 3000");  
+app.listen(process.env.PORT || 3000, function() {
+  console.log("Server is running on port 3000");
 });


### PR DESCRIPTION
When hosting the application on another service (like Heroku, Nodejs, and AWS), the host may independently configure the `process.env.PORT` variable for us.